### PR TITLE
Allowed to use empty AWS credentials (accessKeyId, secretAccessKey)

### DIFF
--- a/lib/fileSystemS3.js
+++ b/lib/fileSystemS3.js
@@ -7,10 +7,10 @@ const hostname = require('os').hostname()
 const instanceId = crypto.createHash('sha1').update(hostname + __dirname).digest('hex') // eslint-disable-line no-path-concat
 
 module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3Options = {} }) => {
-  if (!accessKeyId) {
+  if (accessKeyId != null) {
     throw new Error('The fs store is configured to use aws s3 persistence but the accessKeyId is not set. Use store.persistence.accessKeyId or extensions.fs-store-aws-s3-persistence.accessKeyId to set the proper value.')
   }
-  if (!secretAccessKey) {
+  if (secretAccessKey != null) {
     throw new Error('The fs store is configured to use aws s3 persistence but the accousecretAccessKeyntKey is not set. Use store.persistence.secretAccessKey or extensions.fs-store-aws-s3-persistence.secretAccessKey to set the proper value.')
   }
   if (!bucket) {


### PR DESCRIPTION
Hi, 
in our case we use AWS IAM roles as credentials that don't require to use AWS `accessKeyId` and  `secretAccessKey` for S3 buckets (and others services). Unfortunately with current implementation if we configure `jsreport.config.json` like this:
```
"fs-store-aws-s3-persistence": {
      "accessKeyId": "",
      "secretAccessKey": "",
     ...
    }
```
it throws an error in `fileSystemS3.js:11`.

If we use some dummy credentials:
```
"fs-store-aws-s3-persistence": {
      "accessKeyId": "secret",
      "secretAccessKey": "secret",
     ...
    }
```
AWS S3 service starts to check `accessKeyId` and  `secretAccessKey` and forbid to connect.

Our suggestion is to check not for `falsy` values but for `undefined`/`null` values which will allow to use empty strings. So if somebody is using AWS IAM roles as credentials it is possible to configure like that:
``` 
"fs-store-aws-s3-persistence": {
      "accessKeyId": "",
      "secretAccessKey": "",
      "bucket": "bucket-name",
     ...
    }
```