### PR TITLE
Allowed to use empty AWS credentials (accessKeyId, secretAccessKey)

### DIFF
--- a/lib/fileSystemS3.js
+++ b/lib/fileSystemS3.js
@@ -7,10 +7,10 @@ const hostname = require('os').hostname()
 const instanceId = crypto.createHash('sha1').update(hostname + __dirname).digest('hex') // eslint-disable-line no-path-concat
 
 module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3Options = {} }) => {
-  if (accessKeyId != null) {
+  if (accessKeyId == null) {
     throw new Error('The fs store is configured to use aws s3 persistence but the accessKeyId is not set. Use store.persistence.accessKeyId or extensions.fs-store-aws-s3-persistence.accessKeyId to set the proper value.')
   }
-  if (secretAccessKey != null) {
+  if (secretAccessKey == null) {
     throw new Error('The fs store is configured to use aws s3 persistence but the accousecretAccessKeyntKey is not set. Use store.persistence.secretAccessKey or extensions.fs-store-aws-s3-persistence.secretAccessKey to set the proper value.')
   }
   if (!bucket) {


### PR DESCRIPTION
Hi Jan,

sorry my last PR has a critical typo https://github.com/jsreport/jsreport-fs-store-aws-s3-persistence/pull/3
It must be `==` but not `!=` otherwise it will throw an error for all current connections.

Can you please review this one and sorry again for my mistake.

Thank you in advance!