### PR TITLE
accessKeyId and secretKey are optional. fixed AWS SDK promisify bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Create a bucket and copy its name. Then alter the jsreport configuration:
     "compactionInterval": 20000
   },
   "fs-store-aws-s3-persistence": {
-    "accessKeyId": "...",
-    "secretAccessKey": "...",
     "bucket": "...",
     // the rest is otional
+    "accessKeyId": "...",
+    "secretAccessKey": "...",
     "lock": {
       "queueName": "jsreport-lock.fifo",
       "region": "us-east-1",

--- a/lib/fileSystemS3.js
+++ b/lib/fileSystemS3.js
@@ -7,21 +7,20 @@ const hostname = require('os').hostname()
 const instanceId = crypto.createHash('sha1').update(hostname + __dirname).digest('hex') // eslint-disable-line no-path-concat
 
 module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3Options = {} }) => {
-  if (accessKeyId == null) {
-    throw new Error('The fs store is configured to use aws s3 persistence but the accessKeyId is not set. Use store.persistence.accessKeyId or extensions.fs-store-aws-s3-persistence.accessKeyId to set the proper value.')
-  }
-  if (secretAccessKey == null) {
-    throw new Error('The fs store is configured to use aws s3 persistence but the accousecretAccessKeyntKey is not set. Use store.persistence.secretAccessKey or extensions.fs-store-aws-s3-persistence.secretAccessKey to set the proper value.')
-  }
   if (!bucket) {
     throw new Error('The fs store is configured to use aws s3 persistence but the bucket is not set. Use store.persistence.bucket or extensions.fs-store-aws-s3-persistence.bucket to set the proper value.')
   }
 
-  const s3 = new S3({ accessKeyId: accessKeyId, secretAccessKey: secretAccessKey, ...s3Options })
-  Promise.promisifyAll(s3)
+  let s3
+  if (accessKeyId && secretAccessKey) {
+     s3 = new S3({ accessKeyId: accessKeyId, secretAccessKey: secretAccessKey, ...s3Options })
+  } else {
+     s3 = new S3({ ...s3Options })
+  } 
+  Promise.promisifyAll(s3, {suffix: "P"});
 
   async function listObjectKeys (p) {
-    const blobs = await s3.listObjectsV2Async({
+    const blobs = await s3.listObjectsV2P({
       Bucket: bucket,
       Prefix: p
     })
@@ -41,7 +40,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
     init: async () => {
       logger.info(`fs store is verifying aws s3 bucket ${bucket} exists and is accessible`)
       try {
-        await s3.headBucketAsync({ Bucket: bucket })
+        await s3.headBucketP({ Bucket: bucket })
       } catch (e) {
         throw new Error(`fs store aws s3 bucket "${bucket}" doesn't exist or user doesn't have permissions to it. ` + e)
       }
@@ -58,10 +57,15 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
         lock.region = lock.region || 'us-east-1'
 
         logger.info(`fs store is verifying SQS for locking in ${lock.region} with name ${lock.queueName} `)
-        sqs = new SQS({ accessKeyId: accessKeyId, secretAccessKey: secretAccessKey, region: lock.region })
-        Promise.promisifyAll(sqs)
+        if (accessKeyId && secretAccessKey) {
+           sqs = new SQS({ accessKeyId: accessKeyId, secretAccessKey: secretAccessKey, region: lock.region })
+        } else {
+           sqs = new SQS({ region: lock.region })
+        } 
+        
+        Promise.promisifyAll(sqs, {suffix: "P"})
 
-        const queueRes = await sqs.createQueueAsync({
+        const queueRes = await sqs.createQueueP({
           QueueName: lock.queueName,
           Attributes: lock.attributes
         })
@@ -69,7 +73,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
       }
     },
     readdir: async (p) => {
-      const res = await s3.listObjectsV2Async({
+      const res = await s3.listObjectsV2P({
         Bucket: bucket,
         Prefix: p
       })
@@ -84,17 +88,17 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
       return [...new Set(topFilesOrDirectories)]
     },
     readFile: async (p) => {
-      const res = await s3.getObjectAsync({
+      const res = await s3.getObjectP({
         Bucket: bucket,
         Key: p
       })
       return res.Body
     },
-    writeFile: (p, c) => s3.putObjectAsync({ Bucket: bucket, Key: p, Body: c }),
+    writeFile: (p, c) => s3.putObjectP({ Bucket: bucket, Key: p, Body: c }),
     appendFile: async (p, c) => {
       let existingBuffer = Buffer.from([])
       try {
-        const res = await s3.getObjectAsync({
+        const res = await s3.getObjectP({
           Bucket: bucket,
           Key: p
         })
@@ -103,25 +107,25 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
         // doesn't exists yet
       }
 
-      return s3.putObjectAsync({ Bucket: bucket, Key: p, Body: Buffer.concat([existingBuffer, Buffer.from(c)]) })
+      return s3.putObjectP({ Bucket: bucket, Key: p, Body: Buffer.concat([existingBuffer, Buffer.from(c)]) })
     },
     rename: async (p, pp) => {
       const objectsToRename = await listObjectKeys(p)
 
       await Promise.all(objectsToRename.map(async (key) => {
         const newName = key.replace(p, pp)
-        await s3.copyObjectAsync({
+        await s3.copyObjectP({
           Bucket: bucket,
           CopySource: `/${bucket}/${key}`,
           Key: newName
         })
       }))
 
-      return Promise.all(objectsToRename.map(key => s3.deleteObjectAsync({ Bucket: bucket, Key: key })))
+      return Promise.all(objectsToRename.map(key => s3.deleteObjectP({ Bucket: bucket, Key: key })))
     },
     exists: async (p) => {
       try {
-        await s3.headObjectAsync({ Bucket: bucket, Key: p })
+        await s3.headObjectP({ Bucket: bucket, Key: p })
         return true
       } catch (e) {
         return false
@@ -130,7 +134,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
     stat: async (p) => {
       // directory always fail for some reason
       try {
-        await s3.headObjectAsync({ Bucket: bucket, Key: p })
+        await s3.headObjectP({ Bucket: bucket, Key: p })
         return { isDirectory: () => false }
       } catch (e) {
         return { isDirectory: () => true }
@@ -140,7 +144,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
     remove: async (p) => {
       const blobsToRemove = await listObjectKeys(p)
 
-      return Promise.all(blobsToRemove.map(e => s3.deleteObjectAsync({ Bucket: bucket, Key: e })))
+      return Promise.all(blobsToRemove.map(e => s3.deleteObjectP({ Bucket: bucket, Key: e })))
     },
     path: {
       join: (a, b) => a ? `${a}/${b}` : b,
@@ -163,7 +167,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
           return this.lock()
         }
 
-        const res = await sqs.receiveMessageAsync({
+        const res = await sqs.receiveMessageP({
           QueueUrl: queueUrl,
           WaitTimeSeconds: 1
         })
@@ -175,7 +179,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
             if (message.sentOn && (message.sentOn + 5000 < Date.now())) {
               logger.debug('s3 another server orphan lock, removing')
               try {
-                await sqs.deleteMessageAsync({ QueueUrl: queueUrl, ReceiptHandle: res.Messages[0].ReceiptHandle })
+                await sqs.deleteMessageP({ QueueUrl: queueUrl, ReceiptHandle: res.Messages[0].ReceiptHandle })
               } catch (e) {
 
               }
@@ -185,7 +189,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
               // unblock the message for other receivers
 
               try {
-                await sqs.changeMessageVisibilityAsync({
+                await sqs.changeMessageVisibilityP({
                   QueueUrl: queueUrl,
                   ReceiptHandle: res.Messages[0].ReceiptHandle,
                   VisibilityTimeout: 0
@@ -202,7 +206,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
             logger.debug('s3 orphan lock, removing')
             // orphan message, just remove it
             try {
-              await sqs.deleteMessageAsync({ QueueUrl: queueUrl, ReceiptHandle: res.Messages[0].ReceiptHandle })
+              await sqs.deleteMessageP({ QueueUrl: queueUrl, ReceiptHandle: res.Messages[0].ReceiptHandle })
             } catch (e) {
 
             }
@@ -217,7 +221,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
         return waitForMessage()
       }
 
-      await sqs.sendMessageAsync({
+      await sqs.sendMessageP({
         QueueUrl: queueUrl,
         MessageBody: JSON.stringify({ instanceId, lockId, sentOn: Date.now() }),
         MessageGroupId: 'default',
@@ -234,7 +238,7 @@ module.exports = ({ logger, accessKeyId, secretAccessKey, bucket, lock = {}, s3O
 
       logger.debug('releasing s3 lock')
       try {
-        await sqs.deleteMessageAsync({ QueueUrl: queueUrl, ReceiptHandle: l.Messages[0].ReceiptHandle })
+        await sqs.deleteMessageP({ QueueUrl: queueUrl, ReceiptHandle: l.Messages[0].ReceiptHandle })
         logger.debug('s3 lock released')
       } catch (e) {
         logger.debug('release lock failed')


### PR DESCRIPTION
I changed a little bit the way the accessKeyId and secretKey are used. Before both were mandatory for S3 but were not used for SQS. In my version both are optional for S3 and SQS. So, you so can use a AWS Role for the Lambda and don't need to use the keys. But you can use them, if you work locally. 

A newer version of the AWS SDK was used, but this version has problem with Promise.promisifyAll(): 
`Error occured during reporter init TypeError: Cannot promisify an API that has normal methods with 'Async'-suffix`
My suggestion would be to use a different suffix (e.g. "P") and not "Async".